### PR TITLE
Fix NPE when no joker is selected

### DIFF
--- a/src/gui/views/GameView.java
+++ b/src/gui/views/GameView.java
@@ -425,9 +425,8 @@ public class GameView extends View implements GameInterface {
     	
     	if (selectedJoker != null) {
         	selectedJoker.invoke();	
+        	logLine(selectedJoker.getLogMessage(), game.getCurrentPlayer());
     	}
-    	
-    	logLine(selectedJoker.getLogMessage(), game.getCurrentPlayer());
     	
     	updateJokers();
     }


### PR DESCRIPTION
Fix #26. Jetzt wird keine `NullPointerException` mehr geworfen, wenn kein Joker ausgewählt ist.