### PR TITLE
Hauptstadt statt Flagburg

### DIFF
--- a/src/game/goals/CaptureTheFlagStandardGoal.java
+++ b/src/game/goals/CaptureTheFlagStandardGoal.java
@@ -22,7 +22,7 @@ import game.map.Castle;
 public class CaptureTheFlagStandardGoal extends CaptureTheFlagGoal {
 
 	public CaptureTheFlagStandardGoal() {
-		super("Capture the Flag (Letzte Flagge)", "Derjenige Spieler gewinnt, der es schafft am längsten seine Flagburg zu halten.\n\nIm Teammodus gewinnt das gesamte Team des Siegers.");
+		super("Capture the Flag (Letzte Flagge)", "Derjenige Spieler gewinnt, der es schafft am längsten seine Hauptstadt zu halten.\n\nIm Teammodus gewinnt das gesamte Team des Siegers.");
 	}
 
 	@Override

--- a/src/gui/components/MapPanel.java
+++ b/src/gui/components/MapPanel.java
@@ -288,7 +288,7 @@ public class MapPanel extends JScrollPane {
                     Rectangle iconCheck = getBoundsIconCheck(castlePos);
                     if (iconCheck.contains(mousePos)) {
                         if(game.getGoal() instanceof game.CaptureTheFlagGoal && game.allCastlesChosen()) {
-                    		setToolTipText("Diese Burg als Flagburg besetzen");
+                    		setToolTipText("Diese Burg als Hauptstadt besetzen");
                     	} else {
                     		setToolTipText("Diese Burg besetzen");
                     	}

--- a/src/gui/views/GameView.java
+++ b/src/gui/views/GameView.java
@@ -145,7 +145,7 @@ public class GameView extends View implements GameInterface {
                     if (game.getCurrentPlayer().getRemainingTroops() > 0) {
                         if (game.getRound() == 1) {
                             if(game.allCastlesChosen() && !game.allFlagsDistributed() && game.getGoal() instanceof game.CaptureTheFlagGoal) {
-                        		JOptionPane.showMessageDialog(this, "Du musst noch eine Flagburg auswählen.", "Flagburg wählen", JOptionPane.WARNING_MESSAGE);
+                        		JOptionPane.showMessageDialog(this, "Du musst noch eine Hauptstadt auswählen.", "Hauptstadt wählen", JOptionPane.WARNING_MESSAGE);
                         		return;
                         	}
                             int troops = game.getCurrentPlayer().getRemainingTroops();
@@ -254,7 +254,7 @@ public class GameView extends View implements GameInterface {
     @Override
     public void onCastleChosen(Castle castle, Player player) {
         if(game.allCastlesChosen()) {  // If allCastlesChosen() --> there is only picking flagCastles, only occurs in CTF
-    		logLine("%PLAYER% wählt "  + castle.getName() + " als Flagburg.", player);
+    		logLine("%PLAYER% wählt "  + castle.getName() + " als Hauptstadt.", player);
     	} else {
     		logLine("%PLAYER% wählt "  + castle.getName() + ".", player);
     	}
@@ -267,7 +267,7 @@ public class GameView extends View implements GameInterface {
         this.logLine("%PLAYER% ist am Zug.", currentPlayer);
 
         if(game.getRound() == 1 && game.getGoal() instanceof game.CaptureTheFlagGoal && game.allCastlesChosen()) {
-        	this.logLine("%PLAYER% muss eine Flagburg auswählen.", currentPlayer);
+        	this.logLine("%PLAYER% muss eine Hauptstadt auswählen.", currentPlayer);
         } else if (game.getRound() == 1) {
             this.logLine("%PLAYER% muss " + troopsGot + " Burgen auswählen.", currentPlayer);
         } else {

--- a/src/gui/views/InfoView.java
+++ b/src/gui/views/InfoView.java
@@ -33,7 +33,7 @@ public class InfoView extends View {
             "Nach dem Wählen der Burgen wird noch eine der Burgen aus dem vorhandenen Besitz gewählt, in der die Flagge des Spielers aufgestellt wird.\n" +
             "Mindestens 3 Truppen müssen immer in der Burg zurückbleiben, um die Flagge zu verteidigen.\n" +
             "Wird die Burg mit der Flagge von einem gegnerischen Spieler erobert, hat der Spieler sofort verloren.\n" +
-            "Der Gewinner ist somit derjenige, der am Ende noch seine Flagburg hält.\n\n" +
+            "Der Gewinner ist somit derjenige, der am Ende noch seine Hauptstadt hält.\n\n" +
             "Alle Spielmodi sind auch in Teams bestreitbar, in denen man in Bündnissen zusammen arbeitet,\n" +
             "sich Truppen schenken kann und über befreundetes Gebiet hinweg angreifen kann."
             ;


### PR DESCRIPTION
In den angezeigten Texten ist nun die Rede von Hauptstädten und Flaggen astatt von Flagburgen